### PR TITLE
feat(users): campos de auditoria e soft delete

### DIFF
--- a/implementacoes_completas.md
+++ b/implementacoes_completas.md
@@ -23,42 +23,21 @@ Entregáveis de Auditoria (docs/processo):
 - PR template com checklist de riscos
 - Documento `GOVERNANCE_AUDIT.md` com checklist e plano de ação
 
-Próximas entregas sugeridas (alto valor):
-- Ampliar testes e2e e documentação de erros (antes busque terminar as implementacoes de `implementação_geral.md`. )
-
 Segurança e Qualidade de Dados:
 - Hash seguro de senha com `bcryptjs` no `UsersService` (create/update)
 - Campo `passwordHash` excluído de respostas (ClassSerializer via `@Exclude`)
 - Email com `citext` + índice único (unicidade case-insensitive)
 
-Próximas entregas sugeridas (alto valor):
-- Ampliar testes e2e e documentação de erros (antes busque terminar as implementacoes de `implementação_geral.md`. )
-
 Testes adicionais:
 - Testes unitários do `UsersController` com service mock
 
-Próximas entregas sugeridas (alto valor):
-- Ampliar testes e2e e documentação de erros (antes busque terminar as implementacoes de `implementação_geral.md`. )
+Campos de Auditoria e Ciclo de Vida:
+- Campo `avatarUrl` (opcional) na entidade User e DTOs
+- Campo `deletedAt` para soft delete (DeleteDateColumn)
+- Campo `version` para optimistic lock (VersionColumn)
+- Migração `AddUserAuditFields` para adicionar novos campos
+- Soft delete implementado no `UsersService.remove()`
 
-Próximas entregas sugeridas (alto valor):
-- Templates de governança: issues/PR, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`
-- `.env.example` versionado (sem segredos)
-
-
-#Novidades (entregues):
-- ValidationPipe global e documentação Swagger (`/api/docs`)
-- Endpoint `GET /health` para healthcheck
-- Templates de governança: issues/PR, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`
-- `.env.example` versionado (sem segredos)
- - Tratamento de erros padronizado via filtro global (`HttpExceptionFilter`)
-
-#Próximas entregas sugeridas (alto valor):
-- Ampliar testes e2e e documentação de erros (antes busque terminar as implementacoes de `implementação_geral.md`. )
-
-
-#Próximas entregas sugeridas (alto valor):
-- Templates de governança: issues/PR, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`
-- `.env.example` versionado (sem segredos)
-
+Próximas entregas sugeridas (cite elas):
 
 Ver também: `implementacoes.md` e `implementação_geral.md`.

--- a/src/migrations/1758646964162-AddUserAuditFields.ts
+++ b/src/migrations/1758646964162-AddUserAuditFields.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUserAuditFields1758646964162 implements MigrationInterface {
+  name = 'AddUserAuditFields1758646964162';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE users 
+      ADD COLUMN IF NOT EXISTS avatar_url varchar(500),
+      ADD COLUMN IF NOT EXISTS deleted_at timestamptz,
+      ADD COLUMN IF NOT EXISTS version int NOT NULL DEFAULT 1
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE users 
+      DROP COLUMN IF EXISTS avatar_url,
+      DROP COLUMN IF EXISTS deleted_at,
+      DROP COLUMN IF EXISTS version
+    `);
+  }
+}

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -5,6 +5,7 @@ import {
   MinLength,
   IsOptional,
   IsBoolean,
+  IsUrl,
 } from 'class-validator';
 import { UserRole } from '../entities/user.entity';
 
@@ -24,4 +25,8 @@ export class CreateUserDto {
   @IsOptional()
   @IsBoolean()
   isActive?: boolean;
+
+  @IsOptional()
+  @IsUrl()
+  avatarUrl?: string;
 }

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -5,6 +5,7 @@ import {
   MinLength,
   IsOptional,
   IsBoolean,
+  IsUrl,
 } from 'class-validator';
 import { UserRole } from '../entities/user.entity';
 
@@ -28,4 +29,8 @@ export class UpdateUserDto {
   @IsOptional()
   @IsBoolean()
   isActive?: boolean;
+
+  @IsOptional()
+  @IsUrl()
+  avatarUrl?: string;
 }

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,10 +1,12 @@
 import {
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   Entity,
   Index,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
+  VersionColumn,
 } from 'typeorm';
 import { Exclude } from 'class-transformer';
 
@@ -41,9 +43,18 @@ export class User {
   @Column({ name: 'is_active', type: 'boolean', default: true })
   isActive!: boolean;
 
+  @Column({ name: 'avatar_url', type: 'varchar', length: 500, nullable: true })
+  avatarUrl?: string;
+
   @CreateDateColumn({ name: 'created_at', type: 'timestamp with time zone' })
   createdAt!: Date;
 
   @UpdateDateColumn({ name: 'updated_at', type: 'timestamp with time zone' })
   updatedAt!: Date;
+
+  @DeleteDateColumn({ name: 'deleted_at', type: 'timestamp with time zone' })
+  deletedAt?: Date;
+
+  @VersionColumn({ name: 'version', type: 'int', default: 1 })
+  version!: number;
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -51,7 +51,7 @@ export class UsersService {
   }
 
   async remove(id: string): Promise<void> {
-    const user = await this.findOne(id);
-    await this.userRepository.remove(user);
+    await this.findOne(id); // Verifica se existe
+    await this.userRepository.softDelete(id);
   }
 }


### PR DESCRIPTION
- Adiciona campo avatarUrl (opcional) na entidade User e DTOs\n- Implementa soft delete com campo deletedAt (DeleteDateColumn)\n- Adiciona campo version para optimistic lock (VersionColumn)\n- Migração AddUserAuditFields para novos campos\n- Atualiza UsersService.remove() para usar softDelete\n- Atualiza implementacoes_completas.md\n\nCI: lint/build/test